### PR TITLE
Use latest Amazon Linux version and convert yum to dnf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the latest Amazon Linux 2 as the base image
-FROM amazonlinux:2
+FROM amazonlinux:latest
 
 # Define arguments for versions
 ARG PYTHON_VERSIONS
@@ -7,9 +7,9 @@ ARG MSODBC_VERSION
 ARG UNIXODBC_VERSION
 
 # Install pyenv dependencies and required build tools
-RUN yum -y update && \
-    yum -y install gcc gcc-c++ make automake autoconf libtool bison flex \
-                   openssl11-devel zlib-devel glibc-devel tar gzip zip \
+RUN dnf -y update && \
+    dnf -y install gcc gcc-c++ make automake autoconf libtool bison flex \
+                   openssl-devel zlib-devel glibc-devel tar gzip zip \
                    patch zlib-devel bzip2 bzip2-devel readline-devel \
                    sqlite sqlite-devel tk-devel \
                    libffi-devel xz-devel git wget
@@ -18,9 +18,9 @@ RUN yum -y update && \
 RUN curl https://pyenv.run | bash
 
 # Set up environment for pyenv
-ENV HOME /root
-ENV PYENV_ROOT $HOME/.pyenv
-ENV PATH $PYENV_ROOT/bin:$PATH
+ENV HOME=/root
+ENV PYENV_ROOT=$HOME/.pyenv
+ENV PATH=$PYENV_ROOT/bin:$PATH
 RUN echo 'eval "$(pyenv init --path)"' >> $HOME/.bashrc
 
 # Download and build unixODBC
@@ -34,17 +34,17 @@ RUN curl ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-${UNIXODBC_VERSION}.tar.gz
 # Conditional ODBC Driver Installation Logic
 RUN if [[ "${MSODBC_VERSION}" == "18" || "${MSODBC_VERSION}" == "17" ]]; then \
         curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/mssql-release.repo && \
-        ACCEPT_EULA=Y yum install -y msodbcsql${MSODBC_VERSION}; \
+        ACCEPT_EULA=Y dnf install -y msodbcsql${MSODBC_VERSION}; \
     elif [[ "${MSODBC_VERSION}" == "13.1" ]]; then \
         curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/mssql-release.repo && \
         wget https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/openssl-libs-1.0.2k-26.el7_9.x86_64.rpm && \
         rpm -ivh openssl-libs-1.0.2k-26.el7_9.x86_64.rpm --force && \
-        ACCEPT_EULA=Y yum  install -y msodbcsql; \
+        ACCEPT_EULA=Y dnf  install -y msodbcsql; \
     elif [[ "${MSODBC_VERSION}" == "13" ]]; then \
         curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/mssql-release.repo && \
         wget https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/openssl-libs-1.0.2k-26.el7_9.x86_64.rpm && \
         rpm -ivh openssl-libs-1.0.2k-26.el7_9.x86_64.rpm --force && \
-        ACCEPT_EULA=Y yum install -y msodbcsql-13.0.1.0-1; \
+        ACCEPT_EULA=Y dnf install -y msodbcsql-13.0.1.0-1; \
     else \
         echo "Unsupported ODBC version"; \
         exit 1; \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, this project supports only x86_64 architecture. Future updates will i
 ## Features
 
 - **Version-Specific Artifacts**: Lambda layers are built for specific combinations of:
-  - **Python versions**: ```3.9```, ```3.10```,```3.11```, ```3.12``` (using [pyenv](https://github.com/pyenv/pyenv))
+  - **Python versions**: ```3.9```, ```3.10```,```3.11```, ```3.12```, ```3.13``` (using [pyenv](https://github.com/pyenv/pyenv))
   - **Microsoft ODBC driver versions**: ```17```, ```18```(using [Microsoft ODBC driver versions](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server))
   - **UNIXODBC versions**: ```2.3.12``` (with support for [multiple ODBC versions](https://www.unixodbc.org/download.html))
 
@@ -59,7 +59,8 @@ To build the Lambda layers locally, you can follow these steps:
 
     ```bash
     docker build \
-      --build-arg PYTHON_VERSIONS="3.12,3.11,3.10,3.9" \
+      --platform linux/amd64 \ 
+      --build-arg PYTHON_VERSIONS="3.13,3.12,3.11,3.10,3.9" \
       --build-arg MSODBC_VERSION=18 \
       --build-arg UNIXODBC_VERSION=2.3.12 \
       -t pyodbc-lambda-layer:multi-python .
@@ -81,7 +82,7 @@ If you want to test the Lambda layers, simply push your code to the relevant bra
 
 ## Roadmap
 
-- **Current Support**: The layers support the x86_64 architecture for Python ```3.9```, ```3.10```, ```3.11```, ```3.12``` with Microsoft ODBC Driver versions ```17``` and ```18```, and UNIXODBC ```2.3.12```.
+- **Current Support**: The layers support the x86_64 architecture for Python ```3.9```, ```3.10```, ```3.11```, ```3.12```, ```3.13``` with Microsoft ODBC Driver versions ```17``` and ```18```, and UNIXODBC ```2.3.12```.
 - **Future Updates**:
   - **ARM64 Support**: In future releases, support for the arm64 architecture will be added, allowing for broader compatibility across different AWS Lambda runtime environments.
 


### PR DESCRIPTION
um is no longer supported in the latest version of Amazon Linux so any yum commands needed to be converted to dnf.  The latest version of Amazon Linux was needed to build for Python 3.13 which is the latest version of Python available through AWS.