### PR TITLE
feat: update base image and add Python 3.13 support for AWS Lambda layers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - feature/**
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
       - main
+      - feature/**
 
 jobs:
   build:
@@ -29,7 +31,7 @@ jobs:
       - name: Build Docker image for AWS Lambda layer
         run: |
           docker build \
-            --build-arg PYTHON_VERSIONS="3.11,3.12" \
+            --build-arg PYTHON_VERSIONS="3.9,3.10,3.11,3.12,3.13" \
             --build-arg MSODBC_VERSION=${{ matrix.msodbc_version }} \
             --build-arg UNIXODBC_VERSION=${{ matrix.unixodbc_version }} \
             -t pyodbc-lambda-layer:multi-python .
@@ -57,7 +59,7 @@ jobs:
 
     strategy:
       matrix:
-        python_version: ["3.11", "3.12"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         msodbc_version: ["17", "18"]
         unixodbc_version: ["2.3.12"]
 
@@ -153,7 +155,10 @@ jobs:
 
             We are excited to announce the release of the AWS Lambda layer artifacts that provide seamless connectivity to Microsoft SQL Server databases using the [pyodbc](https://pypi.org/project/pyodbc) library.
 
-            This release includes version-specific zip files tailored for various combinations of Python versions, Microsoft ODBC driver versions, and UNIXODBC versions. You can use these artifacts to easily integrate SQL Server connectivity into your AWS Lambda functions without the hassle of manual configuration.
+            ### New Additions:
+              - Updated the Docker Base image to support latest Amazon linux.
+              - Added support for Python 3.13 with Microsoft ODBC Driver 18 and UNIXODBC 2.3.12.
+              - Updated CI/CD pipeline to automate builds for Python 3.13.
 
             ### Available packages for this release:
 
@@ -165,6 +170,8 @@ jobs:
               - **pyodbc-layer-3.11-mssql17-unixODBC2.3.12.zip**: For Python 3.11 with Microsoft ODBC Driver 17 and UNIXODBC 2.3.12.
               - **pyodbc-layer-3.12-mssql18-unixODBC2.3.12.zip**: For Python 3.12 with Microsoft ODBC Driver 18 and UNIXODBC 2.3.12.
               - **pyodbc-layer-3.12-mssql17-unixODBC2.3.12.zip**: For Python 3.12 with Microsoft ODBC Driver 17 and UNIXODBC 2.3.12.
+              - **pyodbc-layer-3.13-mssql18-unixODBC2.3.12.zip**: For Python 3.13 with Microsoft ODBC Driver 18 and UNIXODBC 2.3.12.
+              - **pyodbc-layer-3.13-mssql17-unixODBC2.3.12.zip**: For Python 3.13 with Microsoft ODBC Driver 17 and UNIXODBC 2.3.12.
 
             ### Key Features:
             - **Automated CI/CD**: Our GitHub Actions CI/CD pipeline ensures that the latest Lambda layer artifacts are consistently built, tested, and released whenever new versions are pushed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the latest Amazon Linux 2 as the base image
-FROM amazonlinux:2
+FROM amazonlinux:latest
 
 # Define arguments for versions
 ARG PYTHON_VERSIONS
@@ -7,9 +7,9 @@ ARG MSODBC_VERSION
 ARG UNIXODBC_VERSION
 
 # Install pyenv dependencies and required build tools
-RUN yum -y update && \
-    yum -y install gcc gcc-c++ make automake autoconf libtool bison flex \
-                   openssl11-devel zlib-devel glibc-devel tar gzip zip \
+RUN dnf -y update && \
+    dnf -y install gcc gcc-c++ make automake autoconf libtool bison flex \
+                   openssl-devel zlib-devel glibc-devel tar gzip zip \
                    patch zlib-devel bzip2 bzip2-devel readline-devel \
                    sqlite sqlite-devel tk-devel \
                    libffi-devel xz-devel git wget
@@ -18,9 +18,9 @@ RUN yum -y update && \
 RUN curl https://pyenv.run | bash
 
 # Set up environment for pyenv
-ENV HOME /root
-ENV PYENV_ROOT $HOME/.pyenv
-ENV PATH $PYENV_ROOT/bin:$PATH
+ENV HOME=/root
+ENV PYENV_ROOT=$HOME/.pyenv
+ENV PATH=$PYENV_ROOT/bin:$PATH
 RUN echo 'eval "$(pyenv init --path)"' >> $HOME/.bashrc
 
 # Download and build unixODBC
@@ -34,17 +34,17 @@ RUN curl ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-${UNIXODBC_VERSION}.tar.gz
 # Conditional ODBC Driver Installation Logic
 RUN if [[ "${MSODBC_VERSION}" == "18" || "${MSODBC_VERSION}" == "17" ]]; then \
         curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/mssql-release.repo && \
-        ACCEPT_EULA=Y yum install -y msodbcsql${MSODBC_VERSION}; \
+        ACCEPT_EULA=Y dnf install -y msodbcsql${MSODBC_VERSION}; \
     elif [[ "${MSODBC_VERSION}" == "13.1" ]]; then \
         curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/mssql-release.repo && \
         wget https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/openssl-libs-1.0.2k-26.el7_9.x86_64.rpm && \
         rpm -ivh openssl-libs-1.0.2k-26.el7_9.x86_64.rpm --force && \
-        ACCEPT_EULA=Y yum  install -y msodbcsql; \
+        ACCEPT_EULA=Y dnf  install -y msodbcsql; \
     elif [[ "${MSODBC_VERSION}" == "13" ]]; then \
         curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/mssql-release.repo && \
         wget https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/openssl-libs-1.0.2k-26.el7_9.x86_64.rpm && \
         rpm -ivh openssl-libs-1.0.2k-26.el7_9.x86_64.rpm --force && \
-        ACCEPT_EULA=Y yum install -y msodbcsql-13.0.1.0-1; \
+        ACCEPT_EULA=Y dnf install -y msodbcsql-13.0.1.0-1; \
     else \
         echo "Unsupported ODBC version"; \
         exit 1; \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, this project supports only x86_64 architecture. Future updates will i
 ## Features
 
 - **Version-Specific Artifacts**: Lambda layers are built for specific combinations of:
-  - **Python versions**: ```3.9```, ```3.10```,```3.11```, ```3.12``` (using [pyenv](https://github.com/pyenv/pyenv))
+  - **Python versions**: ```3.9```, ```3.10```,```3.11```, ```3.12```, ```3.13``` (using [pyenv](https://github.com/pyenv/pyenv))
   - **Microsoft ODBC driver versions**: ```17```, ```18```(using [Microsoft ODBC driver versions](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server))
   - **UNIXODBC versions**: ```2.3.12``` (with support for [multiple ODBC versions](https://www.unixodbc.org/download.html))
 
@@ -59,7 +59,8 @@ To build the Lambda layers locally, you can follow these steps:
 
     ```bash
     docker build \
-      --build-arg PYTHON_VERSIONS="3.12,3.11,3.10,3.9" \
+      --platform linux/amd64 \ 
+      --build-arg PYTHON_VERSIONS="3.13,3.12,3.11,3.10,3.9" \
       --build-arg MSODBC_VERSION=18 \
       --build-arg UNIXODBC_VERSION=2.3.12 \
       -t pyodbc-lambda-layer:multi-python .
@@ -81,7 +82,7 @@ If you want to test the Lambda layers, simply push your code to the relevant bra
 
 ## Roadmap
 
-- **Current Support**: The layers support the x86_64 architecture for Python ```3.9```, ```3.10```, ```3.11```, ```3.12``` with Microsoft ODBC Driver versions ```17``` and ```18```, and UNIXODBC ```2.3.12```.
+- **Current Support**: The layers support the x86_64 architecture for Python ```3.9```, ```3.10```, ```3.11```, ```3.12```, ```3.13``` with Microsoft ODBC Driver versions ```17``` and ```18```, and UNIXODBC ```2.3.12```.
 - **Future Updates**:
   - **ARM64 Support**: In future releases, support for the arm64 architecture will be added, allowing for broader compatibility across different AWS Lambda runtime environments.
 


### PR DESCRIPTION
- Switched to an updated Docker base image for better compatibility and performance.
- Added support for Python 3.13 in PyODBC Lambda layers with MSSQL.
- Enhanced CI/CD workflows to trigger only for feature and main branches.